### PR TITLE
use haskell-platform instead of ghc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
             python \
             php7.0-cli \
             rustc \
-            ghc \
+            haskell-platform \
             libjavascriptcoregtk-4.0-bin \
             golang \
             ruby \


### PR DESCRIPTION
`haskell-platform` includes many core libraries that are widely used.